### PR TITLE
Exponential backoff retries for script download

### DIFF
--- a/Source/ArmTemplate.json
+++ b/Source/ArmTemplate.json
@@ -65,6 +65,32 @@
             }
         },
         {
+            "type": "Microsoft.Automation/automationAccounts/variables",
+            "apiVersion": "2023-11-01",
+            "name": "[concat(parameters('AutomationAccountName'), '/DownloadRetryMaxAttempts')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts/', parameters('AutomationAccountName'))]"
+            ],
+            "properties": {
+                "isEncrypted": false,
+                "value": "5",
+                "description": "Maximum number of download retries for the runbook"
+            }
+        },
+        {
+            "type": "Microsoft.Automation/automationAccounts/variables",
+            "apiVersion": "2023-11-01",
+            "name": "[concat(parameters('AutomationAccountName'), '/DownloadRetryInitialDelaySeconds')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Automation/automationAccounts/', parameters('AutomationAccountName'))]"
+            ],
+            "properties": {
+                "isEncrypted": false,
+                "value": "2",
+                "description": "Initial delay (seconds) used for exponential back-off between download retries"
+            }
+        },
+        {
             "type": "Microsoft.Automation/automationAccounts/powerShell72Modules",
             "apiVersion": "2023-11-01",
             "name": "[concat(parameters('AutomationAccountName'), '/Az.Accounts')]",


### PR DESCRIPTION
Customers are getting 429 throttling errors when the AzureSqlBulkFailover runbook bootstrapper script attempts to download the failover script from github. Assumed to be related to [Updated rate limits for unauthenticated requests - GitHub Changelog](https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/).

This change addresses this problem with exponential backoff retries. User can override retry settings with Runbook variables.

Testing:
1. Executed locally 1000s of times (yet did not reproduces this issue).
2. Executed locally with simulated failures (50% chance).
3. Deployed from the private branch to the test subscription and executed. Script was downloaded as expected.
