### PR TITLE
Fix bug 4650547: Az.ResourceGraph module is not imported before Graph query

### DIFF
--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -25,6 +25,9 @@ catch {
     # do nothing
 }
 
+# Import all needed modules
+Import-Module Az.ResourceGraph
+
 # Create a list to store the log messages with their level to be displayed at end of script execution
 $global:LogList = [System.Collections.Generic.List[Tuple[string,int]]]::new()
 
@@ -615,3 +618,4 @@ catch {
 }
 
 #endregion
+

--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -20,16 +20,10 @@ $global:SleepTime = 15;
 $global:LogLevel = 'Info';
 try {
     $global:LogLevel = Get-AutomationVariable -Name 'LogLevel'    
-    Log -message "Setting logging level to $($global:LogLevel)" -logLevel "Verbose"
 }
 catch {
     # do nothing
 }
-
-# Import all needed modules
-Log -message "Module Import: Az.ResourceGraph" -logLevel "Verbose"
-Import-Module Az.ResourceGraph
-Log -message "Module Import Complete" -logLevel "Verbose"
 
 # Create a list to store the log messages with their level to be displayed at end of script execution
 $global:LogList = [System.Collections.Generic.List[Tuple[string,int]]]::new()
@@ -551,6 +545,14 @@ class BulkFailover{
 # Main method that runs the script to failover all databases and elastic pools in a resource group
 try
 {
+    Log -message "LogLevel = $($global:LogLevel)" -logLevel "Minimal"
+    Log -message "CheckPlannedMaintenanceNotification = $($global:CheckPlannedMaintenanceNotification)" -logLevel "Minimal"
+
+    # Import all needed modules
+    Log -message "Module Import: Az.ResourceGraph" -logLevel "Verbose"
+    Import-Module Az.ResourceGraph
+    Log -message "Module Import Complete" -logLevel "Verbose"
+
     # Ensure we do not inherit the AzContext in the runbook
     Disable-AzContextAutosave -Scope Process | Out-Null
     
@@ -621,6 +623,7 @@ catch {
 }
 
 #endregion
+
 
 
 

--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -20,6 +20,7 @@ $global:SleepTime = 15;
 $global:LogLevel = 'Info';
 try {
     $global:LogLevel = Get-AutomationVariable -Name 'LogLevel'    
+    Log -message "Setting logging level to $($global:LogLevel)" -logLevel "Verbose"
 }
 catch {
     # do nothing
@@ -28,7 +29,7 @@ catch {
 # Import all needed modules
 Log -message "Module Import: Az.ResourceGraph" -logLevel "Verbose"
 Import-Module Az.ResourceGraph
-Log -message "Module Import Complete"
+Log -message "Module Import Complete" -logLevel "Verbose"
 
 # Create a list to store the log messages with their level to be displayed at end of script execution
 $global:LogList = [System.Collections.Generic.List[Tuple[string,int]]]::new()
@@ -620,5 +621,6 @@ catch {
 }
 
 #endregion
+
 
 

--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -627,9 +627,3 @@ catch {
 }
 
 #endregion
-
-
-
-
-
-

--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -71,7 +71,7 @@ function GetPlannedNotificationId($subscriptionId) {
                 trackingId = tostring(properties.TrackingId)
             | where eventType == 'PlannedMaintenance' 
                 and status == 'Active' 
-//                and summary contains 'azsqlcmwselfservicemaint'
+                and summary contains 'azsqlcmwselfservicemaint'
             | summarize arg_max(notificationTime, *) by trackingId
             | project trackingId
 "@
@@ -627,6 +627,7 @@ catch {
 }
 
 #endregion
+
 
 
 

--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -99,13 +99,15 @@ function GetPlannedNotificationId($subscriptionId) {
     # Azure Graph treats certain failures, including query parse failures, as logical failures, not API failures. 
     # In these cases the response code may be 2xx, but there is an embedded message. Translate to exception. 
     $content = $response.Content | ConvertFrom-Json
-    if ($content.error) {
+    if ($content.PSObject.Properties.Match('error').Count -gt 0 -or $content.PSObject.Properties.Match('data').Count -ne 1) {
+        Log -message "Raw response content: $($content)" -logLevel "Always"
+
         $errorMessage = $content.error.message
         Log -message "Resource Graph query failed: $errorMessage" -logLevel "Always"
         throw "Unexpected Graph query error: $errorMessage"
     }
     
-    [PSCustomObject[]]$notifications = ($content).data
+    [PSCustomObject[]]$notifications = $content.data
 
     if ($null -ne $notifications -and $notifications.Count -gt 0) {
         return $notifications[0].trackingId;
@@ -650,4 +652,5 @@ catch {
 }
 
 #endregion
+
 

--- a/Source/AzureSqlBulkFailover.ps1
+++ b/Source/AzureSqlBulkFailover.ps1
@@ -26,7 +26,9 @@ catch {
 }
 
 # Import all needed modules
+Log -message "Module Import: Az.ResourceGraph" -logLevel "Verbose"
 Import-Module Az.ResourceGraph
+Log -message "Module Import Complete"
 
 # Create a list to store the log messages with their level to be displayed at end of script execution
 $global:LogList = [System.Collections.Generic.List[Tuple[string,int]]]::new()
@@ -618,4 +620,5 @@ catch {
 }
 
 #endregion
+
 


### PR DESCRIPTION
If CheckPlannedMaintenanceNotification is set to true, the AzureSqlBulkFailover runbook tries to query Azure Resource Graph for planned maintenance notification information. This fails with "_The 'Search-AzGraph' command was found in the module 'Az.ResourceGraph', but the module could not be loaded. For more information, run 'Import-Module Az.ResourceGraph'._"

The simple solution would be "Import-Module Az.ResourceGraph", but this is blocked by "_This module requires Az.Accounts version 4.2.0. An earlier version of Az.Accounts is imported in the current PowerShell session. Please open a new session before importing this module. This error could indicate that multiple incompatible versions of the Azure PowerShell cmdlets are installed on your system. Please see https://aka.ms/azps-version-error for troubleshooting information_."

The latter error occurs because Azure Automation imports an older 2.* version of Az.Accounts, and the latest version of Az.ResourceGraph is not compatible with this version. 

To sidestep the module version compat issues, we switch to direct REST calls to Graph. Test details in [4650547](https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/4650547/?view=edit). 

Testing performed by deploying a runbook from private branch. Scenarios: 
* End-to-end successful execution, including UpgradeMeNow/Failover calls. 
* GetPlannedNotificationId() can retrieve a planned maintenance event ID after the switch to Invoke-AzRestMethod. 
* Runbook execution fails with the expected message if there is no pending CMW maintenance notification and the CheckPlannedMaintenanceNotification runbook account variable is set to True. 
